### PR TITLE
Feature -- Import additional details into Client

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-libsignal-protocol",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "A Libsignal-Protocol wrapper for NativeScript.",
   "main": "src/libsignal-protocol",
   "typings": "src/index.d.ts",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -230,6 +230,7 @@ export namespace LibsignalProtocol {
     static importSignedPreKeyRecord(serialized: any): TypeDef.SignedPreKeyRecord;
     static importSignedPreKey(serialized: any[]): TypeDef.SignedPreKeyRecord;
     static importIdentityKey(serialized: any[]): TypeDef.IdentityKey;
+    static importIdentityKeyPair(serialized: any): TypeDef.IdentityKeyPair;
     static importPublicKey(serialized: any): TypeDef.ECPublicKey;
     static createPreKeySignalMessage(serialized: any): TypeDef.PreKeySignalMessage;
     static createPreKeyRecord(id: number, keyPair: TypeDef.ECKeyPair): TypeDef.PreKeyRecord;
@@ -494,7 +495,8 @@ export namespace LibsignalProtocol {
     public username: string;
     public deviceId: number;
   
-    constructor(clientName: string, registrationId: number, deviceId: number);
+    constructor(clientName: string, registrationId: number, deviceId: number, identityKeyPairStr?: string, signedPreKeyStr?: string, importedPreKeys?: any[]);
+    
     public hasContact(contactName: string): boolean;
     public generatePreKeyBatch(): any[];
     public importPrivatePreKeys(privatePreKeys: any[]): void;

--- a/src/libsignal-protocol.common.ts
+++ b/src/libsignal-protocol.common.ts
@@ -195,6 +195,7 @@ export declare class CoreDef {
   static importSignedPreKeyRecord(serialized: any): TypeDef.SignedPreKeyRecord;
   static importSignedPreKey(serialized: any[]): TypeDef.SignedPreKeyRecord;
   static importIdentityKey(serialized: any[]): TypeDef.IdentityKey;
+  static importIdentityKeyPair(serialized: any): TypeDef.IdentityKeyPair;
   static importPublicKey(serialized: any): TypeDef.ECPublicKey;
   static createPreKeySignalMessage(serialized: any): TypeDef.PreKeySignalMessage;
   static createPreKeyRecord(id: number, keyPair: TypeDef.ECKeyPair): TypeDef.PreKeyRecord;
@@ -349,7 +350,7 @@ export declare class ClientDef {
   public username: string;
   public deviceId: number;
 
-  constructor(clientName: string, registrationId: number, deviceId: number);
+  constructor(clientName: string, registrationId: number, deviceId: number, identityKeyPairStr?: string, signedPreKeyStr?: string, importedPreKeys?: any[]);
 
   public hasContact(contactName: string): boolean;
   public generatePreKeyBatch(): any[];

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativescript-libsignal-protocol",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "A Libsignal-Protocol wrapper for NativeScript.",
   "main": "libsignal-protocol",
   "typings": "index.d.ts",


### PR DESCRIPTION
Previously, you could only provide three require parameters to the `LibsignalProtocol.Client` class. Upon instantiation, a new `IdentityKeyPair`,  `SignedPreKeyRecord`, and `UnsignedPreKeyRecords` would be generated.

With this update, you can now pass previously serialized information allowing the Client to be restored from a previous saved state.